### PR TITLE
feat(group): quick unassign workspace group with middle-click on all

### DIFF
--- a/src/commands/polybar/module_groups.rs
+++ b/src/commands/polybar/module_groups.rs
@@ -27,7 +27,7 @@ pub fn exec(mut args: Vec<String>) {
 
 		all_button.actions = Some(Actions {
 			left_click: Some(this_command_abs() + " polybar group all"),
-			middle_click: None,
+			middle_click: Some(this_command_abs() + " group assign"),
 			right_click: None,
 		});
 


### PR DESCRIPTION
Quickly unassign workspace from group by middle-clicking on `All` button.