### PR TITLE
fix(polybar): mitigated recursion overflow in polybar watch

### DIFF
--- a/src/commands/polybar/watch.rs
+++ b/src/commands/polybar/watch.rs
@@ -10,16 +10,28 @@ fn update() {
 }
 
 pub fn exec(_: Vec<String>) {
-	let mut i3 = I3Stream::conn_sub(&[Subscribe::Window, Subscribe::Workspace]).unwrap();
-	for e in i3.listen() {
-		match e.unwrap() {
-			Event::Workspace(_) => update(),
-			Event::Window(_) => update(),
-			Event::Output(_) => update(),
-			Event::Mode(_) => update(),
-			Event::BarConfig(_) => update(),
-			_ => {}
+	loop {
+		let mut i3 = match I3Stream::conn_sub(&[Subscribe::Window, Subscribe::Workspace]) {
+			Ok(stream) => stream,
+			Err(err) => {
+				eprintln!("Failed to connect to i3 IPC: {}", err);
+				continue;
+			}
+		};
+
+		for e in i3.listen() {
+			match e {
+				Ok(Event::Workspace(_))
+				| Ok(Event::Window(_))
+				| Ok(Event::Output(_))
+				| Ok(Event::Mode(_))
+				| Ok(Event::BarConfig(_)) => update(),
+				Ok(_) => {}
+				Err(err) => {
+					eprintln!("i3 IPC error: {}", err);
+					break;
+				}
+			}
 		}
 	}
-	exec(vec![]);
 }


### PR DESCRIPTION
## Summary
- prevent recursive calls in polybar `watch` that could overflow the stack

## Testing
- `cargo test`
- `cargo fmt -- --check`


------
https://chatgpt.com/codex/tasks/task_e_687b29aa98f4832aa9879b3ea423bb4b