### PR TITLE
chore(README): install command typo addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This project is **_brand new_**. These steps will become easier and more automat
 
 Distro-specific packages will be coming soon. Star and watch this repo for updates!
 
-- Install `i3-wsm` by placing it in your `PATH`
+- Install `i3-wsman` by placing it in your `PATH`
 
 ### Step 3. Configure
 


### PR DESCRIPTION
## Summary
- correct the command name in installation instructions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b2bb908a4832aa6279fdf0d887cf7