### PR TITLE
fix(goto): aligned warning message with functionality

### DIFF
--- a/src/config/global/navigation/goto_behavior.rs
+++ b/src/config/global/navigation/goto_behavior.rs
@@ -16,7 +16,7 @@ impl FromStr for GotoBehavior {
 		match Self::from_arg(s) {
 			Ok(b) => Ok(b),
 			Err(_) => {
-				eprintln!("Warning: Invalid value '{}' for 'navigation.goto.behavior'. Falling back to 'Stop'.", s);
+				eprintln!("Warning: Invalid value '{}' for 'navigation.goto.behavior'. Falling back to 'Create'.", s);
 				Ok(GotoBehavior::Create)
 			}
 		}


### PR DESCRIPTION
## Summary
- correct fallback warning for invalid `navigation.goto.behavior`

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_687b2c179114832aa4ccd7e3a89fdcc2