### PR TITLE
test(workspace): created tests for name parsing logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate lazy_static;
+
+use i3_ipc::{Connect, I3Stream, I3 as I3_api};
+use std::collections::HashMap;
+
+pub mod commands;
+pub mod common;
+pub mod config;
+pub mod groups;
+pub mod i3;
+pub mod polybar;
+pub mod state;
+
+lazy_static! {
+    pub static ref CONFIG: config::global::Config = config::global::load_cfg();
+    pub static ref POLYBAR_CFG: config::polybar::Config = Default::default();
+    pub static ref I3: I3Stream = I3_api::connect().unwrap();
+}
+
+pub type CommandFn = fn(Vec<String>);
+pub type Commands = HashMap<&'static str, CommandFn>;
+pub type CommandMap = HashMap<&'static str, Commands>;
+
+pub static DEFAULT_CMD: &str = "";
+pub static HELP_CMD: &str = "help";
+pub static WILD_CMD: &str = "*";

--- a/tests/workspace_name.rs
+++ b/tests/workspace_name.rs
@@ -1,0 +1,31 @@
+use i3_wsman::i3::workspace::{parse_name, assemble_name};
+use i3_wsman::config::global::GotoBehavior;
+use std::str::FromStr;
+
+#[test]
+fn parse_name_splits_workspace() {
+    let (num, group, name) = parse_name("1:dev:editor".to_string());
+    assert_eq!(num, "1");
+    assert_eq!(group, "dev");
+    assert_eq!(name, "editor");
+}
+
+#[test]
+fn assemble_name_reassembles_parts() {
+    let name = assemble_name(2, "ops".to_string(), "logs".to_string());
+    assert_eq!(name, "2:ops:logs");
+}
+
+#[test]
+fn parse_and_assemble_roundtrip() {
+    let original = "3:grp:name";
+    let parts = parse_name(original.to_string());
+    let rebuilt = assemble_name(parts.0.parse::<i32>().unwrap(), parts.1, parts.2);
+    assert_eq!(rebuilt, original);
+}
+
+#[test]
+fn goto_behavior_from_str_invalid_returns_create() {
+    let b = GotoBehavior::from_str("invalid").unwrap();
+    assert_eq!(b, GotoBehavior::Create);
+}


### PR DESCRIPTION
## Summary
- add a minimal library interface to expose modules
- create new integration tests for workspace name parsing and assembly
- test GotoBehavior::from_str handling invalid input

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687b2c756378832a83b1584c4311d60f